### PR TITLE
Versjoner av testcontainers må matche docker versjon i Ubuntu Linux på utviklerlaptop

### DIFF
--- a/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
+++ b/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/bytt_til_team_logs
+      deploy_dev_branch: refs/heads/bygg-paa-lokal-ubuntu
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-kandidat-indekser.yaml
+++ b/.github/workflows/deploy-toi-kandidat-indekser.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/oppdater_logg_og_alert
+      deploy_dev_branch: refs/heads/bygg-paa-lokal-ubuntu
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-stilling-indekser.yaml
+++ b/.github/workflows/deploy-toi-stilling-indekser.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/fiks_alert_og_securelog_2
+      deploy_dev_branch: refs/heads/bygg-paa-lokal-ubuntu
     secrets: inherit
     permissions:
       contents: read

--- a/apps/toi-arbeidssoekeropplysninger/build.gradle.kts
+++ b/apps/toi-arbeidssoekeropplysninger/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.testcontainers:testcontainers:1.20.5")
+    testImplementation("org.testcontainers:testcontainers:2.0.4")
     testImplementation("org.testcontainers:postgresql:1.20.5")
     testImplementation("org.testcontainers:junit-jupiter:1.20.5")
     testImplementation("io.mockk:mockk:1.13.16")

--- a/apps/toi-kandidat-indekser/build.gradle.kts
+++ b/apps/toi-kandidat-indekser/build.gradle.kts
@@ -2,12 +2,11 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
-val testContainerVerison = "1.21.3"
 val pamAnsettelseskodeverkVersion = "1.18"
 dependencies {
-    testImplementation("org.testcontainers:elasticsearch:$testContainerVerison")
-    testImplementation("org.testcontainers:junit-jupiter:$testContainerVerison")
-    testImplementation("org.testcontainers:testcontainers:$testContainerVerison")
+    testImplementation("org.testcontainers:elasticsearch:1.21.4")
+    testImplementation("org.testcontainers:junit-jupiter:1.21.4")
+    testImplementation("org.testcontainers:testcontainers:2.0.4")
     implementation("org.opensearch.client:opensearch-java:3.2.0")
     testImplementation("no.nav.arbeid.pam:pam-ansettelseskodeverk:$pamAnsettelseskodeverkVersion")
     testImplementation("io.mockk:mockk:1.13.12")

--- a/apps/toi-stilling-indekser/build.gradle.kts
+++ b/apps/toi-stilling-indekser/build.gradle.kts
@@ -11,8 +11,8 @@ dependencies {
     implementation("org.apache.httpcomponents.client5:httpclient5:5.4.2")
     runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-logback-mdc-1.0:2.16.0-alpha")
 
-    testImplementation("org.opensearch:opensearch-testcontainers:2.1.2")
-    testImplementation("org.testcontainers:kafka:1.20.3")
-    testImplementation("org.testcontainers:junit-jupiter:1.20.6")
+    testImplementation("org.testcontainers:elasticsearch:1.21.4")
+    testImplementation("org.testcontainers:kafka:1.21.4")
+    testImplementation("org.testcontainers:junit-jupiter:1.21.4")
     testImplementation("io.mockk:mockk:1.13.17")
 }

--- a/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchContainer.kt
+++ b/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchContainer.kt
@@ -2,65 +2,16 @@ package no.nav.toi.stilling.indekser
 
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.utility.DockerImageName
-import java.time.Duration
-import java.util.*
 
 class OpenSearchContainer {
 
     val container: ElasticsearchContainer = ElasticsearchContainer(
         DockerImageName.parse("opensearchproject/opensearch:2.11.0")
             .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch")
-    ).withEnv("OPENSEARCH_INITIAL_ADMIN_PASSWORD", OPENSEARCH_PASSWORD)
-        .withEnv("plugins.security.disabled", "true")
+    ).withEnv("plugins.security.disabled", "true")
         .withEnv("discovery.type", "single-node")
-
-    val username: String = "admin"
-    val password: String = OPENSEARCH_PASSWORD
-
-    companion object {
-        private const val OPENSEARCH_PASSWORD = "Admin@12345"
-    }
 
     init {
         container.start()
-        // Wait for the container to be ready by repeatedly checking connectivity
-        waitForReady()
-    }
-
-    private fun waitForReady(maxAttempts: Int = 120, delayMs: Long = 2000) {
-        var attempts = 0
-        var lastError: Exception? = null
-        while (attempts < maxAttempts) {
-            try {
-                // Try to access the health endpoint without auth first
-                val url = java.net.URI("http://${container.httpHostAddress}/_cluster/health").toURL()
-                val connection = url.openConnection() as java.net.HttpURLConnection
-                connection.requestMethod = "GET"
-                connection.connectTimeout = 5000
-                connection.readTimeout = 5000
-                connection.instanceFollowRedirects = true
-                try {
-                    val responseCode = connection.responseCode
-                    if (responseCode in 200..299) {
-                        // Container is ready
-                        return
-                    }
-                } finally {
-                    connection.disconnect()
-                }
-            } catch (e: java.net.SocketTimeoutException) {
-                // Container not ready yet
-                lastError = e
-            } catch (e: java.net.ConnectException) {
-                // Container not ready yet
-                lastError = e
-            } catch (e: Exception) {
-                // Log but continue
-                lastError = e
-            }
-            Thread.sleep(delayMs)
-            attempts++
-        }
-        throw RuntimeException("Timed out waiting for OpenSearch container to be ready after $maxAttempts attempts (${maxAttempts * delayMs}ms). Last error: ${lastError?.message ?: "unknown"}")
     }
 }

--- a/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchContainer.kt
+++ b/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchContainer.kt
@@ -1,17 +1,66 @@
 package no.nav.toi.stilling.indekser
 
-import org.opensearch.testcontainers.OpensearchContainer
+import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.*
 
 class OpenSearchContainer {
 
-    val container: OpensearchContainer<*> = OpensearchContainer(OPENSEARCH_IMAGE).withSecurityEnabled()
+    val container: ElasticsearchContainer = ElasticsearchContainer(
+        DockerImageName.parse("opensearchproject/opensearch:2.11.0")
+            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch")
+    ).withEnv("OPENSEARCH_INITIAL_ADMIN_PASSWORD", OPENSEARCH_PASSWORD)
+        .withEnv("plugins.security.disabled", "true")
+        .withEnv("discovery.type", "single-node")
+
+    val username: String = "admin"
+    val password: String = OPENSEARCH_PASSWORD
 
     companion object {
-        private val OPENSEARCH_IMAGE = DockerImageName.parse("opensearchproject/opensearch:2.11.0")
+        private const val OPENSEARCH_PASSWORD = "Admin@12345"
     }
 
     init {
         container.start()
+        // Wait for the container to be ready by repeatedly checking connectivity
+        waitForReady()
+    }
+
+    private fun waitForReady(maxAttempts: Int = 120, delayMs: Long = 2000) {
+        var attempts = 0
+        var lastError: Exception? = null
+        while (attempts < maxAttempts) {
+            try {
+                // Try to access the health endpoint without auth first
+                val url = java.net.URI("http://${container.httpHostAddress}/_cluster/health").toURL()
+                val connection = url.openConnection() as java.net.HttpURLConnection
+                connection.requestMethod = "GET"
+                connection.connectTimeout = 5000
+                connection.readTimeout = 5000
+                connection.instanceFollowRedirects = true
+                try {
+                    val responseCode = connection.responseCode
+                    if (responseCode in 200..299) {
+                        // Container is ready
+                        return
+                    }
+                } finally {
+                    connection.disconnect()
+                }
+            } catch (e: java.net.SocketTimeoutException) {
+                // Container not ready yet
+                lastError = e
+            } catch (e: java.net.ConnectException) {
+                // Container not ready yet
+                lastError = e
+            } catch (e: Exception) {
+                // Log but continue
+                lastError = e
+            }
+            Thread.sleep(delayMs)
+            attempts++
+        }
+        throw RuntimeException("Timed out waiting for OpenSearch container to be ready after $maxAttempts attempts (${maxAttempts * delayMs}ms). Last error: ${lastError?.message ?: "unknown"}")
     }
 }

--- a/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchServiceTest.kt
+++ b/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchServiceTest.kt
@@ -36,8 +36,8 @@ class OpenSearchServiceTest {
     @BeforeEach
     fun init() {
         env["OPEN_SEARCH_URI"] = osContainer.container.httpHostAddress
-        env["OPEN_SEARCH_USERNAME"] = osContainer.username
-        env["OPEN_SEARCH_PASSWORD"] = osContainer.password
+        env["OPEN_SEARCH_USERNAME"] = ""  // Not needed when security is disabled
+        env["OPEN_SEARCH_PASSWORD"] = ""  // Not needed when security is disabled
 
         env["INDEKS_VERSJON"] = "stilling_20250328"
         env["STILLING_API_URL"] = "enUrl"

--- a/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchServiceTest.kt
+++ b/apps/toi-stilling-indekser/src/test/kotlin/no/nav/toi/stilling/indekser/OpenSearchServiceTest.kt
@@ -36,8 +36,8 @@ class OpenSearchServiceTest {
     @BeforeEach
     fun init() {
         env["OPEN_SEARCH_URI"] = osContainer.container.httpHostAddress
-        env["OPEN_SEARCH_USERNAME"] = osContainer.container.username
-        env["OPEN_SEARCH_PASSWORD"] = osContainer.container.password
+        env["OPEN_SEARCH_USERNAME"] = osContainer.username
+        env["OPEN_SEARCH_PASSWORD"] = osContainer.password
 
         env["INDEKS_VERSJON"] = "stilling_20250328"
         env["STILLING_API_URL"] = "enUrl"


### PR DESCRIPTION
Når Are kjører `docker --version` på sin Ubuntu 24.04 får han `Docker version 29.3.1, build c2be9cc`