### PR TITLE
Aktiver Gradle configuration cache for raskere bygg lokalt + Refaktorer byggeskript + Muilgjør Docker layer caching

### DIFF
--- a/.github/workflows/deploy-toi-arbeidsgiver-notifikasjon.yaml
+++ b/.github/workflows/deploy-toi-arbeidsgiver-notifikasjon.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/endre_til_altinn3
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-arbeidsmarked-cv.yaml
+++ b/.github/workflows/deploy-toi-arbeidsmarked-cv.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
+++ b/.github/workflows/deploy-toi-arbeidssoekeropplysninger.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-arbeidssoekerperiode.yaml
+++ b/.github/workflows/deploy-toi-arbeidssoekerperiode.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-geografi.yaml
+++ b/.github/workflows/deploy-toi-geografi.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-hull-i-cv.yaml
+++ b/.github/workflows/deploy-toi-hull-i-cv.yaml
@@ -15,10 +15,9 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read
       id-token: write
       security-events: write
-

--- a/.github/workflows/deploy-toi-identmapper.yaml
+++ b/.github/workflows/deploy-toi-identmapper.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/utvid-identmapper
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-kandidat-indekser.yaml
+++ b/.github/workflows/deploy-toi-kandidat-indekser.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-kvp.yaml
+++ b/.github/workflows/deploy-toi-kvp.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-livshendelse.yaml
+++ b/.github/workflows/deploy-toi-livshendelse.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-ontologitjeneste.yaml
+++ b/.github/workflows/deploy-toi-ontologitjeneste.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-oppfolgingsinformasjon.yaml
+++ b/.github/workflows/deploy-toi-oppfolgingsinformasjon.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-organisasjonsenhet.yaml
+++ b/.github/workflows/deploy-toi-organisasjonsenhet.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-publiser-dir-stillinger.yaml
+++ b/.github/workflows/deploy-toi-publiser-dir-stillinger.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-publisering-til-arbeidsplassen.yaml
+++ b/.github/workflows/deploy-toi-publisering-til-arbeidsplassen.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-sammenstille-kandidat.yaml
+++ b/.github/workflows/deploy-toi-sammenstille-kandidat.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/oppgrader-javalin
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-siste-14a-vedtak.yaml
+++ b/.github/workflows/deploy-toi-siste-14a-vedtak.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-siste-oppfolgingsperiode-pond.yaml
+++ b/.github/workflows/deploy-toi-siste-oppfolgingsperiode-pond.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-siste-oppfolgingsperiode.yaml
+++ b/.github/workflows/deploy-toi-siste-oppfolgingsperiode.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/oppgrader-javalin
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-stilling-indekser.yaml
+++ b/.github/workflows/deploy-toi-stilling-indekser.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-synlighetsmotor.yaml
+++ b/.github/workflows/deploy-toi-synlighetsmotor.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/oppgrader-javalin
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/deploy-toi-veileder.yaml
+++ b/.github/workflows/deploy-toi-veileder.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/deploy-toi-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/chainguard-dockerimage
+      deploy_dev_branch: refs/heads/test-filer-naar-bygger-alt
     secrets: inherit
     permissions:
       contents: read

--- a/apps/toi-arbeidsgiver-notifikasjon/Dockerfile
+++ b/apps/toi-arbeidsgiver-notifikasjon/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-arbeidsgiver-notifikasjon/build.gradle.kts
+++ b/apps/toi-arbeidsgiver-notifikasjon/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.arbeidsgiver.notifikasjon.ApplicationKt")
+}
+
 dependencies {
     implementation("io.javalin:javalin:7.2.0")
 

--- a/apps/toi-arbeidsmarked-cv/Dockerfile
+++ b/apps/toi-arbeidsmarked-cv/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-arbeidsmarked-cv/build.gradle.kts
+++ b/apps/toi-arbeidsmarked-cv/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.arbeidsmarked.cv.ApplicationKt")
+}
+
 dependencies {
     implementation("io.confluent:kafka-avro-serializer:8.1.1")
     implementation("tools.jackson.core:jackson-databind:3.0.4")

--- a/apps/toi-arbeidssoekeropplysninger/Dockerfile
+++ b/apps/toi-arbeidssoekeropplysninger/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-arbeidssoekeropplysninger/build.gradle.kts
+++ b/apps/toi-arbeidssoekeropplysninger/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.arbeidssoekeropplysninger.ApplicationKt")
+}
+
 dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.4"))
 

--- a/apps/toi-arbeidssoekerperiode/Dockerfile
+++ b/apps/toi-arbeidssoekerperiode/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-arbeidssoekerperiode/build.gradle.kts
+++ b/apps/toi-arbeidssoekerperiode/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.arbeidssoekerperiode.ApplicationKt")
+}
+
 dependencies {
     implementation(project(":apps:asr-domain"))
     implementation("org.apache.avro:avro:1.12.0")

--- a/apps/toi-arbeidssoekerperiode/src/test/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekerperiode/ArbeidssoekerperiodeTest.kt
+++ b/apps/toi-arbeidssoekerperiode/src/test/kotlin/no/nav/arbeidsgiver/toi/arbeidssoekerperiode/ArbeidssoekerperiodeTest.kt
@@ -1,12 +1,11 @@
 package no.nav.arbeidsgiver.toi.arbeidssoekerperiode
 
-import no.nav.toi.TestRapid
-import io.micrometer.prometheusmetrics.PrometheusConfig
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.paw.arbeidssokerregisteret.api.v1.Bruker
 import no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType
 import no.nav.paw.arbeidssokerregisteret.api.v1.Metadata
 import no.nav.paw.arbeidssokerregisteret.api.v1.Periode
+import no.nav.toi.TestRapid
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.MockConsumer
 import org.apache.kafka.clients.consumer.OffsetResetStrategy
@@ -20,7 +19,7 @@ class ArbeidssoekerperiodeTest {
     val arbeidssokerperioderTopic = TopicPartition("paw.arbeidssokerperioder-v1", 0)
 
     val behandleMelding: (Periode) -> ArbeidssokerPeriode = { melding ->
-        ArbeidssokerPeriode(melding, PrometheusMeterRegistry(PrometheusConfig.DEFAULT))
+        ArbeidssokerPeriode(melding, SimpleMeterRegistry())
     }
 
     @Test
@@ -59,7 +58,11 @@ class ArbeidssoekerperiodeTest {
         }
     }
 
-    private fun produserArbeidssoekerperiodeMelding(consumer: MockConsumer<Long, Periode>, melding: Periode, offset: Long = 0) {
+    private fun produserArbeidssoekerperiodeMelding(
+        consumer: MockConsumer<Long, Periode>,
+        melding: Periode,
+        offset: Long = 0
+    ) {
         val record = ConsumerRecord(
             arbeidssokerperioderTopic.topic(),
             arbeidssokerperioderTopic.partition(),
@@ -74,12 +77,14 @@ class ArbeidssoekerperiodeTest {
 
     private fun melding() = Periode.newBuilder()
         .setId(UUID.randomUUID())
-        .setStartet(Metadata.newBuilder()
-            .setAarsak("whatever")
-            .setKilde("junit")
-            .setTidspunkt(Instant.now())
-            .setUtfoertAv(Bruker.newBuilder().setId("jeje").setType(BrukerType.SYSTEM).build())
-            .build())
+        .setStartet(
+            Metadata.newBuilder()
+                .setAarsak("whatever")
+                .setKilde("junit")
+                .setTidspunkt(Instant.now())
+                .setUtfoertAv(Bruker.newBuilder().setId("jeje").setType(BrukerType.SYSTEM).build())
+                .build()
+        )
         .setAvsluttet(null)
         .setIdentitetsnummer("01010012345")
         .build()

--- a/apps/toi-evaluertdatalogger/Dockerfile
+++ b/apps/toi-evaluertdatalogger/Dockerfile
@@ -2,5 +2,6 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 ENTRYPOINT ["java", "-Duser.timezone=Europe/Oslo", "-jar", "app.jar"]

--- a/apps/toi-evaluertdatalogger/build.gradle.kts
+++ b/apps/toi-evaluertdatalogger/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("toi.rapids-and-rivers")
 }
+
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.evaluertdatalogger.ApplicationKt")
+}

--- a/apps/toi-geografi/Dockerfile
+++ b/apps/toi-geografi/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-geografi/build.gradle.kts
+++ b/apps/toi-geografi/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.ApplicationKt")
+}
+
 dependencies {
     implementation("org.apache.httpcomponents.client5:httpclient5:5.5")
     testImplementation("com.github.tomakehurst:wiremock-jre8:3.0.1")

--- a/apps/toi-helseapp/Dockerfile
+++ b/apps/toi-helseapp/Dockerfile
@@ -2,5 +2,6 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 ENTRYPOINT ["java", "-Duser.timezone=Europe/Oslo", "-jar", "app.jar"]

--- a/apps/toi-helseapp/build.gradle.kts
+++ b/apps/toi-helseapp/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("toi.rapids-and-rivers")
 }
+
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.ApplicationKt")
+}

--- a/apps/toi-hull-i-cv/Dockerfile
+++ b/apps/toi-hull-i-cv/Dockerfile
@@ -2,5 +2,6 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 ENTRYPOINT ["java", "-Duser.timezone=Europe/Oslo", "-jar", "app.jar"]

--- a/apps/toi-hull-i-cv/build.gradle.kts
+++ b/apps/toi-hull-i-cv/build.gradle.kts
@@ -2,5 +2,9 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.hullicv.ApplicationKt")
+}
+
 dependencies {
 }

--- a/apps/toi-identmapper/Dockerfile
+++ b/apps/toi-identmapper/Dockerfile
@@ -2,5 +2,6 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 ENTRYPOINT ["java", "-Duser.timezone=Europe/Oslo", "-jar", "app.jar"]

--- a/apps/toi-identmapper/build.gradle.kts
+++ b/apps/toi-identmapper/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.identmapper.ApplicationKt")
+}
+
 dependencies {
     implementation("com.github.kittinunf.fuel:fuel:2.3.1")
     implementation("com.github.kittinunf.fuel:fuel-jackson:2.3.1")

--- a/apps/toi-kandidat-indekser/Dockerfile
+++ b/apps/toi-kandidat-indekser/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-kandidat-indekser/build.gradle.kts
+++ b/apps/toi-kandidat-indekser/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.kandidat.indekser.ApplicationKt")
+}
+
 val pamAnsettelseskodeverkVersion = "1.18"
 dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.4"))

--- a/apps/toi-kvp/Dockerfile
+++ b/apps/toi-kvp/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-kvp/build.gradle.kts
+++ b/apps/toi-kvp/build.gradle.kts
@@ -2,5 +2,9 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.kvp.ApplicationKt")
+}
+
 dependencies {
 }

--- a/apps/toi-livshendelse/Dockerfile
+++ b/apps/toi-livshendelse/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-livshendelse/build.gradle.kts
+++ b/apps/toi-livshendelse/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.livshendelser.ApplicationKt")
+}
+
 dependencies {
     implementation("org.apache.avro:avro:1.12.0")
     implementation("io.confluent:kafka-avro-serializer:7.8.0")

--- a/apps/toi-ontologitjeneste/Dockerfile
+++ b/apps/toi-ontologitjeneste/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-ontologitjeneste/build.gradle.kts
+++ b/apps/toi-ontologitjeneste/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.ontologitjeneste.ApplicationKt")
+}
+
 dependencies {
     implementation("com.github.kittinunf.fuel:fuel:2.3.1")
     implementation("com.github.kittinunf.fuel:fuel-jackson:2.3.1")

--- a/apps/toi-oppfolgingsinformasjon/Dockerfile
+++ b/apps/toi-oppfolgingsinformasjon/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-oppfolgingsinformasjon/build.gradle.kts
+++ b/apps/toi-oppfolgingsinformasjon/build.gradle.kts
@@ -2,5 +2,9 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.oppfolgingsinformasjon.ApplicationKt")
+}
+
 dependencies {
 }

--- a/apps/toi-organisasjonsenhet/Dockerfile
+++ b/apps/toi-organisasjonsenhet/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-organisasjonsenhet/build.gradle.kts
+++ b/apps/toi-organisasjonsenhet/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.organisasjonsenhet.ApplicationKt")
+}
+
 dependencies {
     implementation("com.github.kittinunf.fuel:fuel:2.3.1")
     implementation("com.github.kittinunf.fuel:fuel-jackson:2.3.1")

--- a/apps/toi-publiser-dir-stillinger/Dockerfile
+++ b/apps/toi-publiser-dir-stillinger/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-publiser-dir-stillinger/build.gradle.kts
+++ b/apps/toi-publiser-dir-stillinger/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.toi.stilling.publiser.dirstilling.ApplicationKt")
+}
+
 dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.4"))
     testImplementation("org.testcontainers:testcontainers-kafka")

--- a/apps/toi-publisering-til-arbeidsplassen/Dockerfile
+++ b/apps/toi-publisering-til-arbeidsplassen/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-publisering-til-arbeidsplassen/build.gradle.kts
+++ b/apps/toi-publisering-til-arbeidsplassen/build.gradle.kts
@@ -2,5 +2,9 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.toi.stilling.publiser.arbeidsplassen.ApplicationKt")
+}
+
 dependencies {
 }

--- a/apps/toi-sammenstille-kandidat/Dockerfile
+++ b/apps/toi-sammenstille-kandidat/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-sammenstille-kandidat/build.gradle.kts
+++ b/apps/toi-sammenstille-kandidat/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.ApplicationKt")
+}
+
 dependencies {
     implementation("org.postgresql:postgresql:$postgresVersion")
     implementation("org.flywaydb:flyway-core:$flywayVersion")

--- a/apps/toi-siste-14a-vedtak/Dockerfile
+++ b/apps/toi-siste-14a-vedtak/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-siste-14a-vedtak/build.gradle.kts
+++ b/apps/toi-siste-14a-vedtak/build.gradle.kts
@@ -2,5 +2,9 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.siste14avedtak.ApplicationKt")
+}
+
 dependencies {
 }

--- a/apps/toi-siste-oppfolgingsperiode-pond/Dockerfile
+++ b/apps/toi-siste-oppfolgingsperiode-pond/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-siste-oppfolgingsperiode-pond/build.gradle.kts
+++ b/apps/toi-siste-oppfolgingsperiode-pond/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.oppfolgingsperiode.ApplicationKt")
+}
+
 dependencies {
     implementation("org.apache.kafka:kafka-streams:4.2.0")
 }

--- a/apps/toi-siste-oppfolgingsperiode/Dockerfile
+++ b/apps/toi-siste-oppfolgingsperiode/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-siste-oppfolgingsperiode/build.gradle.kts
+++ b/apps/toi-siste-oppfolgingsperiode/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("toi.common")
+    id("toi.app")
 }
 
 dependencies {

--- a/apps/toi-siste-oppfolgingsperiode/build.gradle.kts
+++ b/apps/toi-siste-oppfolgingsperiode/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.app")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.oppfolgingsperiode.ApplicationKt")
+}
+
 dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.21.0")
 

--- a/apps/toi-stilling-indekser/Dockerfile
+++ b/apps/toi-stilling-indekser/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-stilling-indekser/build.gradle.kts
+++ b/apps/toi-stilling-indekser/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
+application {
+    mainClass.set("no.nav.toi.stilling.indekser.ApplicationKt")
+}
+
 dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.4"))
 

--- a/apps/toi-synlighetsmotor/Dockerfile
+++ b/apps/toi-synlighetsmotor/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-synlighetsmotor/build.gradle.kts
+++ b/apps/toi-synlighetsmotor/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.ApplicationKt")
+}
+
 dependencies {
     implementation("org.postgresql:postgresql:42.7.11")
     implementation("org.flywaydb:flyway-core:11.1.0")

--- a/apps/toi-veileder/Dockerfile
+++ b/apps/toi-veileder/Dockerfile
@@ -2,7 +2,8 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 ARG APP_NAME
 WORKDIR /$APP_NAME
-COPY build/libs/*.jar ./
+COPY build/runtime-libs/*.jar ./runtime-libs/
+COPY build/libs/app.jar ./
 
 # Asume that logback.xml is located in the project/app root dir.
 # The unconventional location is a signal to developers to make them aware that we use this file in an unconventional

--- a/apps/toi-veileder/build.gradle.kts
+++ b/apps/toi-veileder/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("toi.rapids-and-rivers")
 }
 
+application {
+    mainClass.set("no.nav.arbeidsgiver.toi.veileder.ApplicationKt")
+}
+
 dependencies {
     implementation("com.github.kittinunf.fuel:fuel:2.3.1")
     implementation("com.github.kittinunf.fuel:fuel-jackson:2.3.1")

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -1,40 +1,33 @@
+import org.gradle.api.tasks.JavaExec
+import org.gradle.jvm.tasks.Jar
+import org.gradle.api.tasks.Sync
+
 plugins {
     id("toi.common")
     application
 }
 
-fun findApplicationClass(projectDir: File, projectName: String): String {
-    return File("${projectDir}/src/main/kotlin")
-        .walk()
-        .find { it.name == "Application.kt" }
-        ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
-        ?.replace("/", ".")
-        ?.replace(".kt", "Kt")
-        ?: throw InvalidUserDataException("Finner ingen Application.kt i prosjektet $projectName")
-}
-
 val runtimeClasspath = configurations.named("runtimeClasspath")
+val jarTask = tasks.named<Jar>("jar")
 
-val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
-    // Delete all jar files in build/libs except app.jar to clean up stale dependencies
-    delete(fileTree(layout.buildDirectory.dir("libs")) {
-        include("*.jar")
-        exclude("app.jar")
-    })
+jarTask.configure {
+    archiveBaseName.set("app")
 }
 
-val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
-    // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
-    dependsOn(deleteStaleRuntimeJars)
+val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
+    /* Keep runtime dependencies in a dedicated directory so cleanup never touches the app jar.
+     Sync cleans stale jars in runtime-libs.
+     If both app.jar and it's dependency jars were in the same directory build/libs, Sync's cleanup could delete
+     app.jar and leave no runnable app artifact. */
     from(runtimeClasspath)
-    into(layout.buildDirectory.dir("libs"))
+    into(layout.buildDirectory.dir("runtime-libs"))
 }
 
 tasks.named<Jar>("jar") {
     dependsOn(copyRuntimeClasspathJars)
-    archiveBaseName.set("app")
-    val mainClass = findApplicationClass(projectDir, project.name)
-    val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
+    val mainClass = tasks.named<JavaExec>("run").flatMap { it.mainClass }
+    val classPath = runtimeClasspath.map { files -> files.joinToString(separator = " ") { "runtime-libs/${it.name}" } }
+
     manifest.attributes(
         "Main-Class" to mainClass,
         "Class-Path" to classPath

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    id("toi.common")
+    application
+}
+
+fun findApplicationClass(projectDir: File, projectName: String): String {
+    return File("${projectDir}/src/main/kotlin")
+        .walk()
+        .find { it.name == "Application.kt" }
+        ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
+        ?.replace("/", ".")
+        ?.replace(".kt", "Kt")
+        ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
+}
+
+val runtimeClasspath = configurations.named("runtimeClasspath")
+
+val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
+    // Delete all jar files in build/libs except app.jar to clean up stale dependencies
+    delete(fileTree(layout.buildDirectory.dir("libs")) {
+        include("*.jar")
+        exclude("app.jar")
+    })
+}
+
+val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
+    // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
+    dependsOn(deleteStaleRuntimeJars)
+    from(runtimeClasspath)
+    into(layout.buildDirectory.dir("libs"))
+}
+
+tasks.named<Jar>("jar") {
+    dependsOn(copyRuntimeClasspathJars)
+    archiveBaseName.set("app")
+    val mainClass = findApplicationClass(projectDir, project.name)
+    val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
+    manifest.attributes(
+        "Main-Class" to mainClass,
+        "Class-Path" to classPath
+    )
+}

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -8,11 +8,6 @@ plugins {
 }
 
 val runtimeClasspath = configurations.named("runtimeClasspath")
-val jarTask = tasks.named<Jar>("jar")
-
-jarTask.configure {
-    archiveBaseName.set("app")
-}
 
 val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
     /* Keep runtime dependencies in a dedicated directory so cleanup never touches the app jar.
@@ -25,6 +20,8 @@ val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
 
 tasks.named<Jar>("jar") {
     dependsOn(copyRuntimeClasspathJars)
+
+    archiveBaseName.set("app")
     val mainClass = tasks.named<JavaExec>("run").flatMap { it.mainClass }
     val classPath = runtimeClasspath.map { files -> files.joinToString(separator = " ") { "runtime-libs/${it.name}" } }
 

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -12,7 +12,7 @@ val runtimeClasspath = configurations.named("runtimeClasspath")
 val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
     /* Keep runtime dependencies in a dedicated directory so cleanup never touches the app jar.
      Sync cleans stale jars in runtime-libs.
-     If both app.jar and it's dependency jars were in the same directory build/libs, Sync's cleanup could delete
+     If both app.jar and its dependency jars were in the same directory build/libs, Sync's cleanup could delete
      app.jar and leave no runnable app artifact. */
     from(runtimeClasspath)
     into(layout.buildDirectory.dir("runtime-libs"))

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -10,7 +10,7 @@ fun findApplicationClass(projectDir: File, projectName: String): String {
         ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
         ?.replace("/", ".")
         ?.replace(".kt", "Kt")
-        ?: throw org.gradle.api.InvalidUserDataException("Finner ingen Application.kt i prosjektet $projectName")
+        ?: throw InvalidUserDataException("Finner ingen Application.kt i prosjektet $projectName")
 }
 
 val runtimeClasspath = configurations.named("runtimeClasspath")

--- a/buildSrc/src/main/kotlin/toi.app.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.app.gradle.kts
@@ -10,7 +10,7 @@ fun findApplicationClass(projectDir: File, projectName: String): String {
         ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
         ?.replace("/", ".")
         ?.replace(".kt", "Kt")
-        ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
+        ?: throw org.gradle.api.InvalidUserDataException("Finner ingen Application.kt i prosjektet $projectName")
 }
 
 val runtimeClasspath = configurations.named("runtimeClasspath")

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
@@ -28,40 +30,43 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
 }
 
+val isTechnicalLib = project.path.startsWith(":technical-libs:")
+val runtimeClasspath = configurations.named("runtimeClasspath")
+
+val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
+    if (!isTechnicalLib) {
+        from(runtimeClasspath)
+        into(layout.buildDirectory.dir("libs"))
+    } else {
+        enabled = false
+    }
+}
 
 tasks {
     named<Jar>("jar") {
-        // Gjør det mulig å bygge hele prosjektet raskere på utviklermaskin med "./gradlew clean build --warning-mode fail --configuration-cache -Dorg.gradle.configuration-cache.parallel=true"
-        notCompatibleWithConfigurationCache("Jar task accesses runtime classpath which is not serializable")
-
-        if (!projectDir.absoluteFile.toString().contains("technical-libs")) {
+        if (!isTechnicalLib) {
             archiveBaseName.set("app")
 
-            manifest {
-                val stiTilApplicationClass = File("${projectDir}/src/main/kotlin")
-                    .walk()
-                    .find { it.name == "Application.kt" }
-                    ?.path?.removePrefix("${project.projectDir}/src/main/kotlin/")
-                    ?.replace("/", ".")
-                    ?.replace(".kt", "Kt")
-                    ?: throw Exception("Finner ingen Application.kt i prosjektet ${project.name}")
-                attributes["Main-Class"] = stiTilApplicationClass
-                attributes["Class-Path"] = configurations.runtimeClasspath.get().joinToString(separator = " ") {
-                    it.name
-                }
-            }
-        }
+            val stiTilApplicationClass = File("${projectDir}/src/main/kotlin")
+                .walk()
+                .find { it.name == "Application.kt" }
+                ?.path?.removePrefix("${project.projectDir}/src/main/kotlin/")
+                ?.replace("/", ".")
+                ?.replace(".kt", "Kt")
+                ?: throw Exception("Finner ingen Application.kt i prosjektet ${project.name}")
 
-        doLast {
-            configurations.runtimeClasspath.get().forEach {
-                val file = layout.buildDirectory.file("libs/${it.name}").get().asFile
-                if (!file.exists())
-                    it.copyTo(file)
-            }
+            manifest.attributes(
+                mapOf(
+                    "Main-Class" to stiTilApplicationClass,
+                    "Class-Path" to runtimeClasspath.get().joinToString(separator = " ") { it.name }
+                )
+            )
+
+            dependsOn(copyRuntimeClasspathJars)
         }
     }
 
-    tasks.withType<Test> {
+    withType<Test> {
         useJUnitPlatform()
         testLogging {
             events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.Sync
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
@@ -33,10 +31,24 @@ dependencies {
 val isTechnicalLib = project.path.startsWith(":technical-libs:")
 val runtimeClasspath = configurations.named("runtimeClasspath")
 
-val copyRuntimeClasspathJars by tasks.registering(Sync::class) {
+val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
+    if (!isTechnicalLib) {
+        // Delete all jar files in build/libs except app.jar to clean up stale dependencies
+        delete(fileTree(layout.buildDirectory.dir("libs")) {
+            include("*.jar")
+            exclude("app.jar")
+        })
+    } else {
+        enabled = false
+    }
+}
+
+val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
     if (!isTechnicalLib) {
         from(runtimeClasspath)
         into(layout.buildDirectory.dir("libs"))
+        // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
+        dependsOn(deleteStaleRuntimeJars)
     } else {
         enabled = false
     }

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
 
 tasks {
     named<Jar>("jar") {
+        // Gjør det mulig å bygge hele prosjektet raskere på utviklermaskin med "./gradlew clean build --warning-mode fail --configuration-cache -Dorg.gradle.configuration-cache.parallel=true"
+        notCompatibleWithConfigurationCache("Jar task accesses runtime classpath which is not serializable")
+
         if (!projectDir.absoluteFile.toString().contains("technical-libs")) {
             archiveBaseName.set("app")
 

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     kotlin("jvm")
-    application
 }
 
 kotlin {
@@ -26,48 +25,6 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.23.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
-}
-
-val isAppModule = !project.path.startsWith(":technical-libs:")
-
-if (isAppModule) {
-    fun findApplicationClass(projectDir: File, projectName: String): String {
-        return File("${projectDir}/src/main/kotlin")
-            .walk()
-            .find { it.name == "Application.kt" }
-            ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
-            ?.replace("/", ".")
-            ?.replace(".kt", "Kt")
-            ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
-    }
-
-    val runtimeClasspath = configurations.named("runtimeClasspath")
-
-    val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
-        // Delete all jar files in build/libs except app.jar to clean up stale dependencies
-        delete(fileTree(layout.buildDirectory.dir("libs")) {
-            include("*.jar")
-            exclude("app.jar")
-        })
-    }
-
-    val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
-        // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
-        dependsOn(deleteStaleRuntimeJars)
-        from(runtimeClasspath)
-        into(layout.buildDirectory.dir("libs"))
-    }
-
-    tasks.named<Jar>("jar") {
-        dependsOn(copyRuntimeClasspathJars)
-        archiveBaseName.set("app")
-        val mainClass = findApplicationClass(projectDir, project.name)
-        val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
-        manifest.attributes(
-            "Main-Class" to mainClass,
-            "Class-Path" to classPath
-        )
-    }
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -28,57 +28,49 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
 }
 
-val isTechnicalLib = project.path.startsWith(":technical-libs:")
-val runtimeClasspath = configurations.named("runtimeClasspath")
+val isAppModule = !project.path.startsWith(":technical-libs:")
 
-fun findApplicationClass(projectDir: File, projectName: String): String {
-    return File("${projectDir}/src/main/kotlin")
-        .walk()
-        .find { it.name == "Application.kt" }
-        ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
-        ?.replace("/", ".")
-        ?.replace(".kt", "Kt")
-        ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
-}
+if (isAppModule) {
+    fun findApplicationClass(projectDir: File, projectName: String): String {
+        return File("${projectDir}/src/main/kotlin")
+            .walk()
+            .find { it.name == "Application.kt" }
+            ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
+            ?.replace("/", ".")
+            ?.replace(".kt", "Kt")
+            ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
+    }
 
-val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
-    if (!isTechnicalLib) {
+    val runtimeClasspath = configurations.named("runtimeClasspath")
+
+    val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
         // Delete all jar files in build/libs except app.jar to clean up stale dependencies
         delete(fileTree(layout.buildDirectory.dir("libs")) {
             include("*.jar")
             exclude("app.jar")
         })
-    } else {
-        enabled = false
     }
-}
 
-val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
-    if (!isTechnicalLib) {
+    val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
         // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
         dependsOn(deleteStaleRuntimeJars)
         from(runtimeClasspath)
         into(layout.buildDirectory.dir("libs"))
-    } else {
-        enabled = false
+    }
+
+    tasks.named<Jar>("jar") {
+        dependsOn(copyRuntimeClasspathJars)
+        archiveBaseName.set("app")
+        val mainClass = findApplicationClass(projectDir, project.name)
+        val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
+        manifest.attributes(
+            "Main-Class" to mainClass,
+            "Class-Path" to classPath
+        )
     }
 }
 
 tasks {
-    named<Jar>("jar") {
-        if (!isTechnicalLib) {
-            dependsOn(copyRuntimeClasspathJars)
-            archiveBaseName.set("app")
-            val mainClass = findApplicationClass(projectDir, project.name)
-            val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
-            manifest.attributes(
-                "Main-Class" to mainClass,
-                "Class-Path" to classPath
-            )
-
-        }
-    }
-
     withType<Test> {
         useJUnitPlatform()
         testLogging {

--- a/buildSrc/src/main/kotlin/toi.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.common.gradle.kts
@@ -31,6 +31,16 @@ dependencies {
 val isTechnicalLib = project.path.startsWith(":technical-libs:")
 val runtimeClasspath = configurations.named("runtimeClasspath")
 
+fun findApplicationClass(projectDir: File, projectName: String): String {
+    return File("${projectDir}/src/main/kotlin")
+        .walk()
+        .find { it.name == "Application.kt" }
+        ?.path?.removePrefix("${projectDir}/src/main/kotlin/")
+        ?.replace("/", ".")
+        ?.replace(".kt", "Kt")
+        ?: throw Exception("Finner ingen Application.kt i prosjektet $projectName")
+}
+
 val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
     if (!isTechnicalLib) {
         // Delete all jar files in build/libs except app.jar to clean up stale dependencies
@@ -45,10 +55,10 @@ val deleteStaleRuntimeJars by tasks.registering(Delete::class) {
 
 val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
     if (!isTechnicalLib) {
-        from(runtimeClasspath)
-        into(layout.buildDirectory.dir("libs"))
         // deleteStaleRuntimeJars runs first to clean up, then Copy adds current dependencies
         dependsOn(deleteStaleRuntimeJars)
+        from(runtimeClasspath)
+        into(layout.buildDirectory.dir("libs"))
     } else {
         enabled = false
     }
@@ -57,24 +67,15 @@ val copyRuntimeClasspathJars by tasks.registering(Copy::class) {
 tasks {
     named<Jar>("jar") {
         if (!isTechnicalLib) {
+            dependsOn(copyRuntimeClasspathJars)
             archiveBaseName.set("app")
-
-            val stiTilApplicationClass = File("${projectDir}/src/main/kotlin")
-                .walk()
-                .find { it.name == "Application.kt" }
-                ?.path?.removePrefix("${project.projectDir}/src/main/kotlin/")
-                ?.replace("/", ".")
-                ?.replace(".kt", "Kt")
-                ?: throw Exception("Finner ingen Application.kt i prosjektet ${project.name}")
-
+            val mainClass = findApplicationClass(projectDir, project.name)
+            val classPath = runtimeClasspath.get().joinToString(separator = " ") { it.name }
             manifest.attributes(
-                mapOf(
-                    "Main-Class" to stiTilApplicationClass,
-                    "Class-Path" to runtimeClasspath.get().joinToString(separator = " ") { it.name }
-                )
+                "Main-Class" to mainClass,
+                "Class-Path" to classPath
             )
 
-            dependsOn(copyRuntimeClasspathJars)
         }
     }
 

--- a/buildSrc/src/main/kotlin/toi.rapids-and-rivers.gradle.kts
+++ b/buildSrc/src/main/kotlin/toi.rapids-and-rivers.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("toi.common")
+    id("toi.app")
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.caching=true
 org.gradle.parallel=true
 kotlin.code.style = official
 org.gradle.jvmargs=-Xmx1000m
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.max-problems=1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,8 @@
 rootProject.name = "toi-rapids-and-rivers"
 
+// https://docs.gradle.org/current/userguide/configuration_cache_enabling.html#config_cache:stable
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 include(
     "apps:toi-arbeidsmarked-cv",
     "apps:toi-veileder",


### PR DESCRIPTION
* Raskere bygg lokalt
* Bedre lesbarhet av byggeskript
* Legger opp til å skille tydeligere i byggeskript mellom apps og fellesbiblioteker. Denne PR-en kan sees i sammenheng med https://github.com/navikt/toi-rapids-and-rivers/pull/199  Bare apper bør bruke Gradle plugin "[application](https://docs.gradle.org/current/userguide/application_plugin.html)", mens libs bør bruke "[Java-library](https://docs.gradle.org/current/userguide/java_library_plugin.html)" istedenfor.

https://trello.com/c/eRZf8ktz